### PR TITLE
Updates DTG Parent Pom's maven plugins

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -31,16 +31,16 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
+				<version>3.6.1</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 				</configuration>
 			</plugin>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-source-plugin</artifactId>
-				<version>2.1.2</version>
+				<version>3.0.1</version>
 				<executions>
 					<execution>
 						<id>attach-sources</id>
@@ -53,7 +53,7 @@
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
 				<artifactId>maven-javadoc-plugin</artifactId>
-				<version>2.8</version>
+				<version>2.10.4</version>
 				<configuration>
 					<quiet>true</quiet>
 				</configuration>


### PR DESCRIPTION
This is a small update to the pom.xml to use the latest maven plugins and to target JDK 1.8 instead of 1.6.